### PR TITLE
chore: upgrade latest libp2p and libipld

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graphsync"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "Implementation of the GraphSync wire protocol"
@@ -9,17 +9,17 @@ repository = "https://github.com/myelnet/rs-graphsync"
 [dependencies]
 anyhow = "1.0.51"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
-ipld_traversal = { path = "./traversal", version = "0.1.0", default_features = false }
+ipld_traversal = { path = "./traversal", version = "0.2.0", default_features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_tuple = "0.5"
 serde_repr = "0.1"
 serde_ipld_dagcbor = "0.2.2"
 serde_bytes = { package = "cs_serde_bytes", version = "0.12" }
-libp2p = { version = "0.46.1", features = ["wasm-ext"] }
+libp2p = { version = "0.50", features = ["wasm-ext"], default-features = false }
 futures = "0.3.21"
 async-std = { version = "1.12.0", features = ["attributes", "unstable"] }
-libipld = { version = "0.13.1", features = ["serde-codec"] }
-thiserror = "1.0"
+libipld = { version = "0.15.0", features = ["serde-codec"] }
+thiserror = "1.0.37"
 smallvec = "1.9.0"
 
 [dev-dependencies]
@@ -27,6 +27,7 @@ hex = "0.4.3"
 rand = "0.8.5"
 clap = { version = "3.2.18", features = ["derive"] }
 criterion = { version = "0.3", features = ["async_futures", "async_std"] }
+libp2p = { version = "0.50", features = ["dns", "macros", "websocket", "mplex", "noise", "identify", "tcp", "async-std"], default-features = false }
 
 [workspace]
 members = [

--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -13,11 +13,12 @@ js-sys = "0.3.59"
 wasm-bindgen-futures = "0.4.32"
 ipld_traversal = { path = "../../traversal", default_features = false }
 graphsync = { path = "../../" }
-libipld = { version = "0.13.1", features = ["serde-codec"] }
-libp2p = { version = "0.46.1", default_features = true }
+libipld = { version = "0.15.0", features = ["serde-codec"] }
+libp2p = { version = "0.50", default_features = true, features = ["mplex", "noise", "async-std"] }
 libp2p_wasm_ws = { path = "../../libp2p-wasm-ws" }
 serde = { version = "1.0", features = ["derive"] }
 getrandom = { version = "0.2", features = ["js"] }
+rustls = "0.20.7"
 
 [dependencies.web-sys]
 version = "0.3.59"

--- a/libp2p-wasm-ws/Cargo.toml
+++ b/libp2p-wasm-ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p_wasm_ws"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "WASM WebSockets transport for Libp2p using wasm-bindgen"
@@ -11,7 +11,7 @@ futures = "0.3.24"
 wasm-bindgen = "0.2.82"
 js-sys = "0.3.59"
 thiserror = "1.0"
-libp2p = "0.46.1"
+libp2p = { version = "0.50", default-features = false }
 parity-send-wrapper = "0.1.0"
 
 [dependencies.web-sys]

--- a/traversal/Cargo.toml
+++ b/traversal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipld_traversal"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "Implementation of IPLD selectors and traversal methods"
@@ -8,7 +8,7 @@ repository = "https://github.com/myelnet/rs-graphsync"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-libipld = { version = "0.13.1", features = ["serde-codec"] }
+libipld = { version = "0.15.0", features = ["serde-codec"] }
 serde_ipld_dagcbor = "0.1.2"
 indexmap = { version = "1.8.0", features = ["serde"] }
 smallvec = "1.8.0"


### PR DESCRIPTION
First pass a dependency upgrades. Might use Tokio instead of async_std for the next release. Will see.