### PR TITLE
feat: new experimental iterators

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@v3
     - name: Build
       run: cargo build --verbose

--- a/traversal/Cargo.toml
+++ b/traversal/Cargo.toml
@@ -16,6 +16,7 @@ thiserror = "1.0"
 unixfs-v1 = "0.2.1"
 integer-encoding = { version = "3.0", default-features = false }
 anyhow = "1.0.51"
+bytes = "1.3.0"
 
 [dev-dependencies]
 hex = "0.4.3"


### PR DESCRIPTION
This PR brings new traversal iterators showing up to 74% performance improvements on large IPLD trees. These will be migrated over in the next major release which should also use the Bytes interface for more efficient block data handling.